### PR TITLE
Fix exception with missing method on 1.19.2

### DIFF
--- a/src/main/java/io/github/racoondog/simplemacros/utils/Util.java
+++ b/src/main/java/io/github/racoondog/simplemacros/utils/Util.java
@@ -14,10 +14,10 @@ public class Util {
     }
 
     public static void sendChatMessage(String message) {
-        if (MinecraftClient.getInstance().player != null) MinecraftClient.getInstance().player.sendChatMessage(message);
+        if (MinecraftClient.getInstance().player != null) MinecraftClient.getInstance().player.sendChatMessage(message, null);
     }
 
     public static void sendCommand(String command) {
-        if (MinecraftClient.getInstance().player != null) MinecraftClient.getInstance().player.sendCommand(command);
+        if (MinecraftClient.getInstance().player != null) MinecraftClient.getInstance().player.sendCommand(command, null);
     }
 }


### PR DESCRIPTION
Mojang decided to remove the `sendChatMessage` method that just takes a String for 1.19.2.
This change passes a null value to the `Text preview` argument. For future proofing, I also added it to `sendCommand`.

I have tested these changes on 1.19.2 but should work fine on older 1.19.x versions